### PR TITLE
Fixed minor error in LoxFunction that executed blocks twice.

### DIFF
--- a/lahari-jlox/src/jloxinterpreter/LoxFunction.java
+++ b/lahari-jlox/src/jloxinterpreter/LoxFunction.java
@@ -30,7 +30,7 @@ class LoxFunction implements LoxCallable {
         catch (Return returnValue) {
             return returnValue.value;
         }
-        interpreter.executeBlock(declaration.body, environment);
+        //interpreter.executeBlock(declaration.body, environment); -> This caused code to be printed twice!
         return null;
     }
 }


### PR DESCRIPTION
Accidentally wrote `interpreter.executeBlock(declaration.body, environment);` twice - once outside the try-catch blocks, causing functions to be executed twice. Corrected this by commenting it out.